### PR TITLE
Update pygments version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 RUN pip3 install Pygments
 
+RUN ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
+ && dpkg-reconfigure --frontend noninteractive tzdata
+
 WORKDIR /home

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-RUN apt-get update --yes \
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update --yes \
  && apt-get install --yes --no-install-recommends \
-    texlive-latex-base texlive-latex-recommended texlive-latex-extra latexmk python-pip \
+    texlive-latex-base texlive-latex-recommended texlive-latex-extra latexmk \
+    python-is-python3 python3-pip \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN pip install Pygments
+RUN pip3 install Pygments
 
 WORKDIR /home


### PR DESCRIPTION
PDF builds for https://github.com/ExaESM-WP4/JupyterHub-Evaluation-Whitepaper/ are failing for the syntax highlighting parts of the document (see also #1). Demanding the newest Pygments version (v2.6.1) solves the problem, but requires an upgrade of the default Python environment. Beginning with Ubuntu 20.04 LTS there is a distro package that solves this automatically, so the base image was upgraded as well. The default Ubuntu 20.04 TeX Live environment requires proper time zone information, though. A fix to enable silent installation of the associated `tzdata` package was necessary for the Docker build to complete properly.